### PR TITLE
Errors in SVRL Schematron

### DIFF
--- a/svrl.sch
+++ b/svrl.sch
@@ -22,7 +22,7 @@ THIS SCHEMA HAS BEEN MODIFIED FROM THE SCHEMA DEFINED IN ISO/IEC 19757 3,
 AND SHOULD NOT BE INTERPRETED AS COMPLYING WITH THAT STANDARD."
 -->
 
-<sch:schema xmlns:sch="http://purl.oclc.org/dsdl/schematron" xml:lang="en">
+<sch:schema queryBinding="xslt2" xmlns:sch="http://purl.oclc.org/dsdl/schematron" xml:lang="en">
     <sch:title>Schema for Schematron Validation Report Language</sch:title>
     <sch:ns prefix="svrl" uri="http://purl.oclc.org/dsdl/svrl"/>
     <sch:p>The Schematron Validation Report Language is a simple language
@@ -36,7 +36,7 @@ AND SHOULD NOT BE INTERPRETED AS COMPLYING WITH THAT STANDARD."
         <sch:title>Elements</sch:title>
         <!--Abstract Rules -->
         <sch:rule abstract="true" id="second-level">
-            <sch:assert test="../svrl:schematron-output"> The <sch:name/> element is a
+            <sch:assert test="parent::svrl:schematron-output"> The <sch:name/> element is a
                 child of schematron-output. </sch:assert>
         </sch:rule>
         <sch:rule abstract="true" id="childless">
@@ -51,11 +51,12 @@ AND SHOULD NOT BE INTERPRETED AS COMPLYING WITH THAT STANDARD."
         </sch:rule>
         <!-- Rules-->
         <sch:rule context="svrl:schematron-output">
-            <sch:assert test="not(../*)"> The <sch:name/> element is the root element.
+            <sch:assert test="parent::document-node()"> The <sch:name/> element is the root element.
             </sch:assert>
             <sch:assert
-                test="count(svrl:text) + count(svrl:ns-prefix-in-attribute-values) +count(svrl:fired-rule) + count(svrl:failed-assert) +
-                count(svrl:successful-report) = count(*)">
+                test="count(svrl:text) + count(svrl:ns-prefix-in-attribute-values) +
+                      count(svrl:active-pattern) + count(svrl:fired-rule) +
+                      count(svrl:failed-assert) + count(svrl:successful-report) = count(*)">
                 <sch:name/> may only contain the following elements: text,
                 ns-prefix-in-attribute-values, active-pattern, fired-rule, failed-assert and
                 successful-report. </sch:assert>
@@ -89,7 +90,7 @@ AND SHOULD NOT BE INTERPRETED AS COMPLYING WITH THAT STANDARD."
             <sch:extends rule="second-level"/>
             <sch:extends rule="empty"/>
             <sch:assert
-                test="preceding-sibling::active-pattern |
+                test="preceding-sibling::svrl:active-pattern |
                 preceding-sibling::svrl:fired-rule |
                 preceding-sibling::svrl:failed-assert |
                 preceding-sibling::svrl:successful-report"


### PR DESCRIPTION
Provided for consideration for the SVRL Schematron in the next Schematron standard.

- 'second-level' rule checked for sibling, not parent
- 'svrl:schematron-output' rule checked that the current element did not exist
- 'svrl:schematron-output' rule failed to count a child element type
- 'svrl:fired-rule' rule omitted namespace when checking for a preceding sibling element